### PR TITLE
Fixed navigation issue. Added history object to Router. And used with…

### DIFF
--- a/src/LandingDashboard/dashboard.js
+++ b/src/LandingDashboard/dashboard.js
@@ -10,6 +10,7 @@ import * as actionTypes from '../store/action';
 import RouterMain from '../routermain';
 import {connect} from 'react-redux';
 import Loading from '../Loader/Loader';
+import {withRouter} from 'react-router-dom'
 
 
 
@@ -240,4 +241,4 @@ const mapStateToProps = state =>{
     mobileOpen:state.mobRed.mobileOpen
   }
 }
-export default withStyles(styles)(connect(mapStateToProps,mapDispatchToProps)(Paperbase));
+export default withRouter(withStyles(styles)(connect(mapStateToProps,mapDispatchToProps)(Paperbase)));

--- a/src/index.js
+++ b/src/index.js
@@ -36,14 +36,9 @@ const getConfirmation = (message, callback) => {
   }
 const app = (
     <Provider store={store}>
-    <BrowserRouter
-        // basename={Routes.BASE_URL}
-        forceRefresh={!supportsHistory}
-        getUserConfirmation={getConfirmation}
-        keyLength={12}
->
+    <Router history={history}>
             <App/>
-        </BrowserRouter>
+        </Router>
     </Provider>
 )
 ReactDOM.render(


### PR DESCRIPTION
…Router HOC for the dashboard.

'connect' from 'react-redux' doesn't let the component re-render after it renders it.
https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/guides/blocked-updates.md#third-party-code